### PR TITLE
UI改善: 保存先表示の改行問題とディレクトリリセット機能の追加

### DIFF
--- a/content.js
+++ b/content.js
@@ -52,6 +52,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     return true;
   }
+  
+  if (message.action === 'clearDirectory') {
+    clearStoredDirectoryHandle()
+      .then(() => sendResponse({ success: true }))
+      .catch(error => sendResponse({ success: false, error: error.message }));
+    return true;
+  }
 });
 
 // ページコンテンツの抽出とMarkdown変換

--- a/popup.html
+++ b/popup.html
@@ -16,15 +16,20 @@
     
     <div class="divider"></div>
     
-    <button id="directoryButton" class="button directory-button">
-      📁 保存先ディレクトリを選択
-    </button>
+    <div class="directory-controls">
+      <button id="directoryButton" class="button directory-button">
+        📁 保存先ディレクトリを選択
+      </button>
+      <button id="resetButton" class="button reset-button hidden" title="保存先をリセット">
+        🗑️
+      </button>
+    </div>
     
     <div class="directory-info">
-      <div class="directory-label">保存先:</div>
-      <div id="directoryPath" class="directory-path empty">
+      <span class="directory-label">保存先: </span>
+      <span id="directoryPath" class="directory-path empty">
         ディレクトリが選択されていません
-      </div>
+      </span>
       <div id="browserInfo" class="browser-info"></div>
     </div>
     

--- a/popup.html
+++ b/popup.html
@@ -21,7 +21,7 @@
         📁 保存先ディレクトリを選択
       </button>
       <button id="resetButton" class="button reset-button hidden" title="保存先をリセット">
-        🗑️
+        リセット
       </button>
     </div>
     

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const saveButton = document.getElementById('saveButton');
   const saveButtonText = document.getElementById('saveButtonText');
   const directoryButton = document.getElementById('directoryButton');
+  const resetButton = document.getElementById('resetButton');
   const directoryPath = document.getElementById('directoryPath');
   const status = document.getElementById('status');
   const statusText = document.getElementById('statusText');
@@ -101,6 +102,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // UIを更新
       await saveDirectoryName(response.data.name);
       updateDirectoryDisplay(response.data.name);
+      showResetButton();
       showStatus('success', 'ディレクトリが選択されました');
       setTimeout(() => hideStatus(), 2000);
       
@@ -115,12 +117,52 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
+  // リセットボタンのクリック処理
+  resetButton.addEventListener('click', async () => {
+    try {
+      // 確認ダイアログを表示
+      const confirmMessage = '保存先ディレクトリの設定をリセットしますか？\n\n次回保存時に改めてディレクトリを選択していただく必要があります。';
+      if (confirm(confirmMessage)) {
+        showStatus('processing', 'ディレクトリ設定をリセット中...');
+        
+        // アクティブタブの取得
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab) {
+          // Content Script経由でディレクトリハンドルをクリア
+          try {
+            await chrome.tabs.sendMessage(tab.id, { action: 'clearDirectory' });
+          } catch (error) {
+            console.log('Content script not available, clearing storage only');
+          }
+        }
+        
+        // ローカルストレージをクリア
+        await chrome.storage.local.set({
+          directoryName: null,
+          hasDirectoryAccess: false
+        });
+        
+        // UIを初期状態に戻す
+        updateDirectoryDisplay(null);
+        hideResetButton();
+        
+        showStatus('success', 'ディレクトリ設定をリセットしました');
+        setTimeout(() => hideStatus(), 2000);
+      }
+    } catch (error) {
+      console.error('ディレクトリリセットエラー:', error);
+      showStatus('error', 'リセットに失敗しました');
+      setTimeout(() => hideStatus(), 3000);
+    }
+  });
+
   // 初期化：保存されたディレクトリ情報を復元
   async function initializeDirectory() {
     try {
       const result = await chrome.storage.local.get(['directoryName', 'hasDirectoryAccess']);
       if (result.directoryName && result.hasDirectoryAccess) {
         updateDirectoryDisplay(result.directoryName);
+        showResetButton();
         // content script内でディレクトリハンドルが保持されているかは不明なので、
         // 新しいページでは再選択が必要であることを示唆
         const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -130,6 +172,8 @@ document.addEventListener('DOMContentLoaded', async () => {
           directoryPath.textContent += ' (HTTPSページでのみ有効)';
           directoryPath.style.color = '#f57c00';
         }
+      } else {
+        hideResetButton();
       }
     } catch (error) {
       console.error('ディレクトリ情報の復元エラー:', error);
@@ -150,8 +194,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // ディレクトリ表示の更新
   function updateDirectoryDisplay(dirName) {
-    directoryPath.textContent = dirName;
-    directoryPath.classList.remove('empty');
+    if (dirName) {
+      directoryPath.textContent = dirName;
+      directoryPath.classList.remove('empty');
+    } else {
+      directoryPath.textContent = 'ディレクトリが選択されていません';
+      directoryPath.classList.add('empty');
+    }
   }
 
   // Markdownファイルの保存
@@ -221,11 +270,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       .substring(0, 100);            // 長さ制限
   }
 
+  // リセットボタンの表示
+  function showResetButton() {
+    resetButton.classList.remove('hidden');
+  }
+
+  // リセットボタンの非表示
+  function hideResetButton() {
+    resetButton.classList.add('hidden');
+  }
+
   // 処理状態の設定
   function setProcessingState(processing) {
     isProcessing = processing;
     saveButton.disabled = processing;
     directoryButton.disabled = processing;
+    resetButton.disabled = processing;
     
     if (processing) {
       saveButtonText.innerHTML = '<span class="spinner"></span>処理中...';

--- a/styles.css
+++ b/styles.css
@@ -86,16 +86,17 @@ body {
 }
 
 .reset-button {
-  background-color: #ff4757;
+  background-color: #6c757d;
   color: white;
-  min-width: 40px;
-  padding: 10px;
-  border: 1px solid #ff3742;
+  min-width: 60px;
+  padding: 10px 12px;
+  border: 1px solid #5a6268;
+  font-size: 13px;
 }
 
 .reset-button:hover:not(:disabled) {
-  background-color: #ff3742;
-  border-color: #ff2838;
+  background-color: #5a6268;
+  border-color: #545b62;
 }
 
 .reset-button.hidden {

--- a/styles.css
+++ b/styles.css
@@ -79,19 +79,45 @@ body {
   border-color: #ccc;
 }
 
+.directory-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.reset-button {
+  background-color: #ff4757;
+  color: white;
+  min-width: 40px;
+  padding: 10px;
+  border: 1px solid #ff3742;
+}
+
+.reset-button:hover:not(:disabled) {
+  background-color: #ff3742;
+  border-color: #ff2838;
+}
+
+.reset-button.hidden {
+  display: none;
+}
+
 .directory-info {
   background-color: #f8f9fa;
   border: 1px solid #e9ecef;
   border-radius: 6px;
   padding: 12px;
   margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px;
 }
 
 .directory-label {
   font-size: 12px;
   font-weight: 500;
   color: #666;
-  margin-bottom: 4px;
 }
 
 .directory-path {


### PR DESCRIPTION
## 概要

GitHub issue #2 で報告されたUI問題を解決しました。

## 変更内容

### 🎨 保存先表示の改行問題の修正
- **問題**: 「保存先:」とディレクトリパスが別行に表示され、UI領域を無駄に使用
- **解決**: HTMLをdiv要素からspan要素に変更し、CSS flexレイアウトで同一行表示を実現
- **効果**: より自然で読みやすい保存先表示

### 🗑️ ディレクトリリセット機能の追加
- **問題**: 一度選択したディレクトリを解除する方法がない
- **解決**: ディレクトリ選択時のみ表示されるリセットボタンを追加
- **機能**:
  - 確認ダイアログによる安全なリセット処理
  - ローカルストレージとIndexedDBの両方をクリア
  - UI状態の適切な管理（ボタンの表示・非表示制御）

### 🎯 デザイン改善
- リセットボタンの視認性向上（アイコン→テキスト「リセット」）
- 危険な赤色から穏やかなグレー系に変更
- ディレクトリ選択ボタンとリセットボタンを横並び配置
- より直感的なユーザーインターフェース

## 影響範囲

- `popup.html`: HTMLレイアウト修正とリセットボタン追加
- `popup.js`: リセットボタンのイベント処理とUI制御ロジック
- `styles.css`: 新しいレイアウトとボタンスタイル  
- `content.js`: リセット用メッセージハンドラ追加

## 主な改善点

| Before | After |
|--------|-------|
| 「保存先:」<br>「ディレクトリ名」（別行表示） | 「保存先: ディレクトリ名」（同一行表示） |
| ディレクトリリセット機能なし | 安全なリセット機能追加 |
| - | 視認性の良いデザイン |

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)